### PR TITLE
Use Refile.cdn_host instead of Refile.host

### DIFF
--- a/lib/inputs/refile_input.rb
+++ b/lib/inputs/refile_input.rb
@@ -11,7 +11,7 @@ class RefileInput < Formtastic::Inputs::FileInput
 
     attacher = object.send(:"#{method}_attacher")
     options[:accept] = attacher.definition.accept
-    host =  options[:host] || Refile.host
+    host =  options[:host] || Refile.cdn_host
 
     if options[:direct]
       backend_name = Refile.backends.key(attacher.cache)


### PR DESCRIPTION
In Refile 0.6.0, the `host` method was deprecated in favor of `cdn_host`. This causes a deprecation warning:

> Refile.host is deprecated, please use Refile.cdn_host instead

Because this gem targets Refile ~> 0.6, I think this change is safe.
